### PR TITLE
Destroy all decorations when Highlight Selected has cleared too.

### DIFF
--- a/lib/minimap-highlight-selected.coffee
+++ b/lib/minimap-highlight-selected.coffee
@@ -34,6 +34,7 @@ class MinimapHighlightSelected
   init: ->
     @decorations = []
     @highlightSelected.onDidAddMarker (marker) => @markerCreated(marker)
+    @highlightSelected.onDidRemoveAllMarkers => @markersDestroyed()
 
   dispose: ->
     @decorations.forEach (decoration) -> decoration.destroy()
@@ -46,6 +47,10 @@ class MinimapHighlightSelected
     decoration = activeMinimap.decorateMarker(marker,
       {type: 'highlight', class: @highlightSelected.makeClasses()})
     @decorations.push decoration
+
+  markersDestroyed: =>
+    @decorations.forEach (decoration) -> decoration.destroy()
+    @decorations = []
 
   deactivatePlugin: ->
     return unless @active


### PR DESCRIPTION
Ok, so I've added an event that gets triggered when all the markers are removed. Which then allows `minimap-highlight-selected` to clear the decorations list to stop it growing forever. 

As with regards to `hideHighlightOnSelectedWord`, when you go from having selection one word to two words (e.g. using `cmd + d`) all the decorations get cleared anyway. So it doesn't have an orphan decoration.

I haven't published the new event yet.