### PR TITLE
check for available decorators before disposing

### DIFF
--- a/lib/minimap-highlight-selected.coffee
+++ b/lib/minimap-highlight-selected.coffee
@@ -53,7 +53,7 @@ class MinimapHighlightSelected
     @decorations.push decoration
 
   markersDestroyed: =>
-    @decorations.forEach (decoration) -> decoration.destroy()
+    @decorations?.forEach (decoration) -> decoration.destroy()
     @decorations = []
 
   deactivatePlugin: ->


### PR DESCRIPTION
Everytime minimap or a plugin gets disabled it emits the event 'did-remove-marker-layer', which calls for the `markersDestroyed`.

It breaks when we never had anything marked in the first place.

This should resolve #36  and #33 