### PR TITLE
Upgrade API consumed version + Add dependency warning

### DIFF
--- a/lib/minimap-highlight-selected.coffee
+++ b/lib/minimap-highlight-selected.coffee
@@ -6,6 +6,8 @@ class MinimapHighlightSelected
     @subscriptions = new CompositeDisposable
 
   activate: (state) ->
+    unless atom.inSpecMode()
+      require('atom-package-deps').install 'minimap-highlight-selected', true
 
   consumeMinimapServiceV1: (@minimap) ->
     @minimap.registerPlugin 'highlight-selected', this

--- a/lib/minimap-highlight-selected.coffee
+++ b/lib/minimap-highlight-selected.coffee
@@ -10,7 +10,7 @@ class MinimapHighlightSelected
   consumeMinimapServiceV1: (@minimap) ->
     @minimap.registerPlugin 'highlight-selected', this
 
-  consumeHighlightSelectedServiceV1: (@highlightSelected) ->
+  consumeHighlightSelectedServiceV2: (@highlightSelected) ->
     @init() if @minimap? and @active?
 
   deactivate: ->
@@ -34,21 +34,21 @@ class MinimapHighlightSelected
 
   init: =>
     @decorations = []
-    @highlightSelected.onDidAddMarker (marker) => @markerCreated(marker)
-    @highlightSelected.onDidAddSelectedMarker (marker) => @markerCreated(marker, true)
+    @highlightSelected.onDidAddMarkerForEditor (options) => @markerCreated(options)
+    @highlightSelected.onDidAddSelectedMarkerForEditor (options) => @markerCreated(options, true)
     @highlightSelected.onDidRemoveAllMarkers => @markersDestroyed()
 
   dispose: =>
     @decorations?.forEach (decoration) -> decoration.destroy()
     @decorations = null
 
-  markerCreated: (marker, selected = false) =>
-    activeMinimap = @minimap.getActiveMinimap()
-    return unless activeMinimap?
+  markerCreated: (options, selected = false) =>
+    minimap = @minimap.minimapForEditor(options.editor)
+    return unless minimap?
     className  = 'highlight-selected'
     className += ' selected' if selected
 
-    decoration = activeMinimap.decorateMarker(marker,
+    decoration = minimap.decorateMarker(options.marker,
       {type: 'highlight', class: className })
     @decorations.push decoration
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "highlightSelected": {
       "versions": {
-        "1.0.0": "consumeHighlightSelectedServiceV1"
+        "2.0.0": "consumeHighlightSelectedServiceV2"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
   "dependencies": {
     "event-kit": ">= 0.7.2",
     "underscore-plus": "1.x",
-    "atom-utils": "0.0.1"
-  }
+    "atom-utils": "0.0.1",
+    "atom-package-deps": "^4.4.1"
+  },
+  "package-deps": [
+    "highlight-selected"
+  ]
 }


### PR DESCRIPTION
I've created a new API version that will fix #32

Also, I've added a package that will tell people they need to install `highlight-selected` as a dependency which should stop people asking why it doesn't work.